### PR TITLE
Add file option, defaults to 'wrangler.toml'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,11 +36,15 @@ const migrateCommand = {
         describe: "Save the generated JSON[C] file",
         type: "boolean",
         default: false,
+      })
+      .option("f", {
+        describe: "Target wrangler file",
+        default: "wrangler.toml",
       });
   },
-  handler: (argv: yargs.Arguments<{ to: string; save: boolean }>) => {
+  handler: (argv: yargs.Arguments<{ to: string; save: boolean, f: string }>) => {
     try {
-      const configPath = join(process.cwd(), "wrangler.toml");
+      const configPath = join(process.cwd(), argv.f);
 
       if (!argv.to.includes("json")) {
         throw new Error("The only supported target format is JSON[C]");


### PR DESCRIPTION
This allows for scenarios where multiple wrangler files are present, but might be prefixed or affixed in their file name. Congruent with the `-c` option in the Wrangler CLI.